### PR TITLE
Upgrade prop_check and reenable property specs for Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         ruby-version: "${{ matrix.ruby }}"
     - name: Bundle
       run: |
-        gem install bundler:2.2.21
+        gem install bundler:2.3.1
         bundle install --no-deployment
     - name: Run tests
       run: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,24 +7,24 @@ GEM
   remote: https://rubygems.org/
   specs:
     amazing_print (1.4.0)
-    diff-lcs (1.3)
+    diff-lcs (1.5.0)
     gemika (0.7.1)
-    prop_check (0.14.1)
+    prop_check (0.18.1)
       amazing_print (~> 1.2)
-    rake (10.4.2)
-    rspec (3.5.0)
-      rspec-core (~> 3.5.0)
-      rspec-expectations (~> 3.5.0)
-      rspec-mocks (~> 3.5.0)
-    rspec-core (3.5.4)
-      rspec-support (~> 3.5.0)
-    rspec-expectations (3.5.0)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-mocks (3.5.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.5.0)
-    rspec-support (3.5.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
     timecop (0.8.1)
 
 PLATFORMS
@@ -33,10 +33,10 @@ PLATFORMS
 DEPENDENCIES
   gemika
   memoized!
-  prop_check (~> 0.14.1)
-  rake (~> 10.4.2)
-  rspec (~> 3.5.0)
+  prop_check (~> 0.18.1)
+  rake (~> 13.0.6)
+  rspec (~> 3.12.0)
   timecop (~> 0.8.0)
 
 BUNDLED WITH
-   2.2.21
+   2.3.1

--- a/memoized.gemspec
+++ b/memoized.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_development_dependency('rake', '~> 10.4.2')
-  s.add_development_dependency('rspec', '~> 3.5.0')
+  s.add_development_dependency('rake', '~> 13.0.6')
+  s.add_development_dependency('rspec', '~> 3.12.0')
   s.add_development_dependency('timecop', '~> 0.8.0')
-  s.add_development_dependency('prop_check', '~> 0.14.1')
+  s.add_development_dependency('prop_check', '~> 0.18.1')
   s.add_development_dependency('gemika')
 end

--- a/spec/properties_spec.rb
+++ b/spec/properties_spec.rb
@@ -1,4 +1,4 @@
-unless RUBY_VERSION == '2.5.3' || RUBY_VERSION == '3.2.0'
+unless RUBY_VERSION == '2.5.3'
   describe "#memoize" do
     include PropCheck
     include PropCheck::Generators


### PR DESCRIPTION
This only updates dev dependencies and reenables some specs for Ruby 3.2