### PR TITLE
Support memoizing methods with block parameters

### DIFF
--- a/lib/memoized.rb
+++ b/lib/memoized.rb
@@ -26,19 +26,21 @@ module Memoized
 
         parameters = Parameters.new(instance_method(unmemoized_method).parameters)
 
+        block_forward = parameters.has_block? ? ", &#{parameters.block_param}" : ''
+
         module_eval(<<-RUBY)
           def #{method_name}(#{parameters.signature})
             #{parameters.cache_key}
 
             #{memoized_ivar_name} ||= {}
-            
+
             if #{memoized_ivar_name}.key?(cache_key)
               #{memoized_ivar_name}[cache_key]
             else
               live_result = if all_kwargs.empty?
-                #{unmemoized_method}(*all_args)
-              else  
-                #{unmemoized_method}(*all_args, **all_kwargs)
+                #{unmemoized_method}(*all_args#{block_forward})
+              else
+                #{unmemoized_method}(*all_args, **all_kwargs#{block_forward})
               end
               #{memoized_ivar_name}[cache_key] = live_result
               live_result

--- a/lib/memoized/parameters.rb
+++ b/lib/memoized/parameters.rb
@@ -2,7 +2,7 @@ module Memoized
   class Parameters
     UNIQUE = 42.freeze
 
-    attr_accessor :req_params, :opt_params, :rest_params, :keyreq_params, :key_params, :keyrest_params
+    attr_accessor :req_params, :opt_params, :rest_params, :keyreq_params, :key_params, :keyrest_params, :block_param
 
     def initialize(parameters = [])
       # This constructor does not check, whether the parameters were ordered correctly
@@ -13,6 +13,7 @@ module Memoized
       @keyreq_params = []
       @key_params = []
       @keyrest_params = []
+      @block_param = nil
 
       parameters.each do |(param_type, param_name)|
         case param_type
@@ -29,7 +30,7 @@ module Memoized
         when :keyrest
           @keyrest_params << [param_type, param_name]
         when :block
-          raise Memoized::CannotMemoize, 'Cannot memoize a method that takes a block!'
+          @block_param = param_name
         else
           raise Memoized::CannotMemoize, 'Unknown parameter type!'
         end
@@ -44,8 +45,16 @@ module Memoized
       @req_params + @opt_params + @rest_params + @keyreq_params + @key_params + @keyrest_params
     end
 
+    def has_block?
+      !@block_param.nil?
+    end
+
     def signature
-      params.map(&Parameters.method(:to_signature)).join(', ')
+      sig = params.map(&Parameters.method(:to_signature)).join(', ')
+      return sig unless has_block?
+
+      block_sig = "&#{@block_param}"
+      sig.empty? ? block_sig : "#{sig}, #{block_sig}"
     end
 
     def self.to_signature((param_type, param_name))

--- a/spec/memoized_spec.rb
+++ b/spec/memoized_spec.rb
@@ -270,6 +270,173 @@ describe Memoized do
 
   end
 
+  describe '.memoize with block parameters' do
+    class BlockNoArgs
+      include Memoized
+      def transform(&block)
+        block.call("hello")
+      end
+      memoize :transform
+    end
+
+    class BlockWithArgs
+      include Memoized
+      def transform(value, &block)
+        block.call(value)
+      end
+      memoize :transform
+    end
+
+    class BlockWithOptional
+      include Memoized
+      def transform(&block)
+        block ? block.call("hello") : "hello"
+      end
+      memoize :transform
+    end
+
+    class BlockWithKwargs
+      include Memoized
+      def transform(prefix:, suffix: "", &block)
+        result = block.call("hello")
+        "#{prefix}#{result}#{suffix}"
+      end
+      memoize :transform
+    end
+
+    class BlockWithAllParamTypes
+      include Memoized
+      def transform(req, opt = ".", *rest, key:, optkey: "", **keyrest, &block)
+        base = block.call(req)
+        "#{base}#{opt}#{rest.join}#{key}#{optkey}#{keyrest.values.join}"
+      end
+      memoize :transform
+    end
+
+    class BlockPrivate
+      include Memoized
+      def public_transform
+        transform(&:upcase)
+      end
+      private
+      def transform(&block)
+        block.call("hello")
+      end
+      memoize :transform
+    end
+
+    context "for a method with only a block parameter" do
+      let(:object) { BlockNoArgs.new }
+
+      it "forwards the block and caches the result" do
+        result = object.transform(&:upcase)
+        expect(result).to eq("HELLO")
+      end
+
+      it "returns the cached result on subsequent calls" do
+        result1 = object.transform(&:upcase)
+        result2 = object.transform(&:reverse)
+        expect(result1).to eq("HELLO")
+        expect(result2).to eq("HELLO")
+      end
+
+      it "can be unmemoized" do
+        object.transform(&:upcase)
+        object.unmemoize(:transform)
+        result = object.transform(&:reverse)
+        expect(result).to eq("olleh")
+      end
+    end
+
+    context "for a method with an optional block" do
+      let(:object) { BlockWithOptional.new }
+
+      it "works when called with a block" do
+        expect(object.transform(&:upcase)).to eq("HELLO")
+      end
+
+      it "works when called without a block" do
+        expect(object.transform).to eq("hello")
+      end
+
+      it "returns cached result when called without a block after being cached with one" do
+        object.transform(&:upcase)
+        expect(object.transform).to eq("HELLO")
+      end
+
+      it "returns cached result when called with a block after being cached without one" do
+        object.transform
+        expect(object.transform(&:upcase)).to eq("hello")
+      end
+    end
+
+    context "for a method with positional args and a block" do
+      let(:object) { BlockWithArgs.new }
+
+      it "forwards both args and block" do
+        result = object.transform("world", &:upcase)
+        expect(result).to eq("WORLD")
+      end
+
+      it "caches per argument, ignoring the block" do
+        result1 = object.transform("world", &:upcase)
+        result2 = object.transform("world", &:reverse)
+        result3 = object.transform("other", &:upcase)
+        expect(result1).to eq("WORLD")
+        expect(result2).to eq("WORLD")
+        expect(result3).to eq("OTHER")
+      end
+    end
+
+    context "for a method with keyword args and a block" do
+      let(:object) { BlockWithKwargs.new }
+
+      it "forwards kwargs and block" do
+        expect(object.transform(prefix: "[", suffix: "]", &:upcase)).to eq("[HELLO]")
+      end
+
+      it "caches per kwargs, ignoring the block" do
+        result1 = object.transform(prefix: "[", &:upcase)
+        result2 = object.transform(prefix: "[", &:reverse)
+        result3 = object.transform(prefix: "(", &:upcase)
+        expect(result1).to eq("[HELLO")
+        expect(result2).to eq("[HELLO")
+        expect(result3).to eq("(HELLO")
+      end
+    end
+
+    context "for a method with all param types and a block" do
+      let(:object) { BlockWithAllParamTypes.new }
+
+      it "forwards everything and caches correctly" do
+        result = object.transform("hi", "!", "a", "b", key: "k", optkey: "o", extra: "e", &:upcase)
+        expect(result).to eq("HI!abkoe")
+      end
+
+      it "caches per args, ignoring the block" do
+        result1 = object.transform("hi", key: "k", &:upcase)
+        result2 = object.transform("hi", key: "k", &:reverse)
+        expect(result1).to eq("HI.k")
+        expect(result2).to eq("HI.k")
+      end
+    end
+
+    context "for a private method with a block" do
+      let(:object) { BlockPrivate.new }
+
+      it "respects method visibility" do
+        expect(BlockPrivate.private_method_defined?(:transform)).to be_truthy
+        expect(BlockPrivate.private_method_defined?(:_unmemoized_transform)).to be_truthy
+      end
+
+      it "memoizes the private method" do
+        result1 = object.public_transform
+        result2 = object.public_transform
+        expect(result1).to eq("HELLO")
+        expect(result2).to eq("HELLO")
+      end
+    end
+  end
 
   describe 'instance methods' do
     class MemoizedSpecClass


### PR DESCRIPTION
## Problem

Calling `memoize` on a method that has a `&block` parameter raises `Memoized::CannotMemoize`. This prevents memoizing methods that use blocks internally (e.g. `transform_values(&:to_s)`) even though the block doesn't affect cacheability.

## Solution

- Track `&block` parameters in `Parameters` instead of raising
- Append the original block parameter to the generated method signature
- Forward the block to the original method on cache miss

The block is **not** part of the cache key since blocks cannot be meaningfully hashed. On cache hit, the cached value is returned regardless of the block passed. This is correct when the block is part of the method's internal implementation rather than an external input that changes the return value.

**Note:** Methods using implicit `yield` without an explicit `&block` parameter are not affected by this change. Ruby does not report a `:block` parameter for such methods, so they remain unchanged.

## Tests

Added specs covering:
- Methods with only a block parameter
- Methods with positional args and a block
- Methods with keyword args and a block
- Methods with all parameter types (req, opt, rest, keyreq, key, keyrest) and a block
- Optional block: called with and without a block, in both orders
- Cache hit returns cached value regardless of block
- `unmemoize` works correctly for block methods
- Private method visibility is preserved

All existing tests continue to pass.